### PR TITLE
Fixed whitelist feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,10 @@ function check() {
 			return process.exit(1);
 		}
 
+		const pattern = /\x1B\[94m(?<dependency>[a-zA-Z\-\_\@\/]+).*/
 		const incompatibleDependencies = Object.keys(dependencies).filter(
-			(dependency) => {
-				if (packageWhitelist.includes(dependency.split("@")[0])) {
+            		(dependency) => {
+                		if (packageWhitelist.includes(dependency.replace(pattern, '$<dependency>'))) {
 					return false;
 				}
 				const licenses = dependencies[dependency].licenses;


### PR DESCRIPTION
Added a regex ([regex101 link](https://regex101.com/r/TOdp9C/1/)), matching dependency names inside colorized strings, in order to fix the whitelist feature (`--allow <dependency>`)

```diff
+ const pattern = /\x1B\[94m(?<dependency>[a-zA-Z\-\_\@\/]+).*/
  const incompatibleDependencies = Object.keys(dependencies).filter(
      (dependency) => {
-          if (packageWhitelist.includes(dependency.split("@")[0])) {
+          if (packageWhitelist.includes(dependency.replace(pattern, '$<dependency>'))) {
                 return false;
           }
```